### PR TITLE
Added optional arguments to events

### DIFF
--- a/CDargonQuest/CDargonQuest.vcxproj
+++ b/CDargonQuest/CDargonQuest.vcxproj
@@ -160,6 +160,7 @@
   </ItemDefinitionGroup>
   <ItemGroup>
     <ClCompile Include="error.c" />
+    <ClCompile Include="event.c" />
     <ClCompile Include="event_queue.c" />
     <ClCompile Include="game.c" />
     <ClCompile Include="clock.c" />
@@ -173,10 +174,12 @@
   <ItemGroup>
     <ClInclude Include="common.h" />
     <ClInclude Include="error.h" />
+    <ClInclude Include="event.h" />
+    <ClInclude Include="event_args.h" />
     <ClInclude Include="event_queue.h" />
     <ClInclude Include="game.h" />
     <ClInclude Include="clock.h" />
-    <ClInclude Include="event.h" />
+    <ClInclude Include="event_type.h" />
     <ClInclude Include="input_handler.h" />
     <ClInclude Include="input_state.h" />
     <ClInclude Include="renderer.h" />

--- a/CDargonQuest/event.c
+++ b/CDargonQuest/event.c
@@ -1,0 +1,10 @@
+#include "event.h"
+
+int dqEvent_GetArgCount( dqEventType_t type )
+{
+   switch ( type )
+   {
+      default:
+         return 0;
+   }
+}

--- a/CDargonQuest/event.h
+++ b/CDargonQuest/event.h
@@ -1,7 +1,13 @@
 #pragma once
 
-typedef enum
+#include "event_type.h"
+#include "event_args.h"
+
+typedef struct
 {
-   dqEventQuit
+   dqEventType_t type;
+   dqEventArgs_t args;
 }
-dqEventType_t;
+dqEvent_t;
+
+int dqEvent_GetArgCount( dqEventType_t type );

--- a/CDargonQuest/event_args.h
+++ b/CDargonQuest/event_args.h
@@ -1,0 +1,9 @@
+#pragma once
+
+#define MAX_EVENT_ARGS 4
+
+typedef struct
+{
+   int args[MAX_EVENT_ARGS];
+}
+dqEventArgs_t;

--- a/CDargonQuest/event_queue.c
+++ b/CDargonQuest/event_queue.c
@@ -26,8 +26,11 @@ sfBool dqEventQueue_IsEmpty()
    return dqEventQueue->back == -1;
 }
 
-void dqEventQueue_Push( dqEventType_t e )
+void dqEventQueue_Push( dqEventType_t type, ... )
 {
+   int argCount, i;
+   va_list args;
+
    dqEventQueue->back++;
 
    if ( dqEventQueue->back >= MAX_EVENTS )
@@ -36,13 +39,26 @@ void dqEventQueue_Push( dqEventType_t e )
    }
    else
    {
-      dqEventQueue->queue[dqEventQueue->back] = e;
+      dqEventQueue->queue[dqEventQueue->back].type = type;
+      argCount = dqEvent_GetArgCount( type );
+
+      if ( argCount > 0 )
+      {
+         va_start( args, argCount );
+
+         for ( i = 0; i < argCount; i++ )
+         {
+            dqEventQueue->queue[dqEventQueue->back].args.args[i] = va_arg( args, int );
+         }
+
+         va_end( args );
+      }
    }
 }
 
-dqEventType_t dqEventQueue_GetNext()
+dqEvent_t* dqEventQueue_GetNext()
 {
-   dqEventType_t e = dqEventQueue->queue[dqEventQueue->front];
+   dqEvent_t* e = &( dqEventQueue->queue[dqEventQueue->front] );
    dqEventQueue->front++;
 
    if ( dqEventQueue->front > dqEventQueue->back )
@@ -53,9 +69,9 @@ dqEventType_t dqEventQueue_GetNext()
    return e;
 }
 
-dqEventType_t dqEventQueue_PeekNext()
+dqEvent_t* dqEventQueue_PeekNext()
 {
-   return dqEventQueue->queue[dqEventQueue->front];
+   return &( dqEventQueue->queue[dqEventQueue->front] );
 }
 
 void dqEventQueue_Flush()

--- a/CDargonQuest/event_queue.h
+++ b/CDargonQuest/event_queue.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <stdarg.h>
+
 #include "common.h"
 #include "event.h"
 
@@ -7,7 +9,7 @@
 
 typedef struct
 {
-   dqEventType_t queue [MAX_EVENTS];
+   dqEvent_t queue [MAX_EVENTS];
    int front;
    int back;
 }
@@ -19,7 +21,7 @@ void dqEventQueue_Init();
 void dqEventQueue_Create();
 void dqEventQueue_Cleanup();
 sfBool dqEventQueue_IsEmpty();
-void dqEventQueue_Push( dqEventType_t e );
-dqEventType_t dqEventQueue_GetNext();
-dqEventType_t dqEventQueue_PeekNext();
+void dqEventQueue_Push( dqEventType_t type, ... );
+dqEvent_t* dqEventQueue_GetNext();
+dqEvent_t* dqEventQueue_PeekNext();
 void dqEventQueue_Flush();

--- a/CDargonQuest/event_type.h
+++ b/CDargonQuest/event_type.h
@@ -1,0 +1,7 @@
+#pragma once
+
+typedef enum
+{
+   dqEventQuit
+}
+dqEventType_t;

--- a/CDargonQuest/game.c
+++ b/CDargonQuest/game.c
@@ -59,7 +59,7 @@ void dqGame_Run()
 
 void dqGame_HandleEvents()
 {
-   static dqEventType_t e;
+   dqEvent_t* e;
 
    dqWindow_HandleEvents();
 
@@ -67,7 +67,7 @@ void dqGame_HandleEvents()
    {
       e = dqEventQueue_GetNext();
 
-      switch ( e )
+      switch ( e->type )
       {
          case dqEventQuit:
             dqGame_Quit();

--- a/CDargonQuest/strings.h
+++ b/CDargonQuest/strings.h
@@ -17,3 +17,4 @@
 #define STR_ERROR_INPUT_STATE_MEMORY      "could not allocate memory for dqInputState object"
 #define STR_ERROR_CLOCK_RESOLUTION        "could not set Windows timer resolution"
 #define STR_ERROR_EVENT_OVERFLOW          "game event queue has overflowed"
+#define STR_ERROR_EVENT_ARG_OVERFLOW      "game event has too many arguments"

--- a/CDargonQuest/window.c
+++ b/CDargonQuest/window.c
@@ -37,7 +37,7 @@ void dqWindow_HandleEvents()
       switch ( e.type )
       {
          case sfEvtClosed:
-            dqEventQueue_Push( dqEventQuit );
+            dqEventQueue_Push( dqEventQuit, 0 );
             break;
          case sfEvtKeyPressed:
             dqInputState_SetKeyPressed( e.key.code );


### PR DESCRIPTION
## Overview

I was debating on how exactly to do this, and ultimately figured it'd be fastest if I allocate memory for event args up front, so I never have to do a `malloc( sizeof( dqEvent_t ) )`. So now if you want to send args, you pass them as function parameters to the event queue's push method.

There's only one event at the moment ("quit"), which doesn't have any args, but this at least paves the way.