### PR TITLE
Fix menu carat blink rate

### DIFF
--- a/CDargonQuest/render_config.c
+++ b/CDargonQuest/render_config.c
@@ -19,7 +19,7 @@ void dqRenderConfig_Init()
    dqRenderConfig->menuFontColor = sfWhite;
    dqRenderConfig->menuCaratText = ">";
    dqRenderConfig->menuCaratOffsetX = -50;
-   dqRenderConfig->menuCaratBlinkRate = 0.5f;
+   dqRenderConfig->menuCaratBlinkRate = 0.3f;
 
    dqRenderConfig->titleMenuOffsetX = 900;
    dqRenderConfig->titleMenuOffsetY = 600;

--- a/CDargonQuest/title_renderer.c
+++ b/CDargonQuest/title_renderer.c
@@ -55,10 +55,10 @@ void dqTitleRenderer_Render()
    {
       dqTitleRenderer->caratElapsedSeconds += dqClock->lastFrameSeconds;
 
-      if ( dqTitleRenderer->caratElapsedSeconds >= dqRenderConfig->menuCaratBlinkRate )
+      while ( dqTitleRenderer->caratElapsedSeconds >= dqRenderConfig->menuCaratBlinkRate )
       {
          dqTitleRenderer->showCarat = dqTitleRenderer->showCarat ? sfFalse : sfTrue;
-         dqTitleRenderer->caratElapsedSeconds = 0;
+         dqTitleRenderer->caratElapsedSeconds -= dqRenderConfig->menuCaratBlinkRate;
       }
    }
 


### PR DESCRIPTION
## Overview

I've run into this before when cycling through animation frames. When a frame has finished, the elapsed animation frame time shouldn't be reset to zero, it should be decremented by the frame time. This way, super-low frame rates won't cause any problems, and inconsistent frame rates will still look smooth.