### PR TITLE
Make menus global

### DIFF
--- a/CDargonQuest/common.h
+++ b/CDargonQuest/common.h
@@ -1,11 +1,14 @@
 #pragma once
 
-#include <stdio.h>
 #include <stdlib.h>
+#include <stdio.h>
+#include <stdarg.h>
 #include <SFML/Graphics.h>
 
 #include "strings.h"
 #include "error.h"
 
 #define SAFE_DELETE( x ) if ( x != NULL ) { free( x ); x = NULL; }
-#define VERIFY_OR_EXIT( x ) if ( !x ) { dqError_ExitWithMessage( STR_ERROR_MEMORY ); }
+
+#define MAX_EVENTS         100
+#define MAX_EVENT_ARGS     4

--- a/CDargonQuest/event.h
+++ b/CDargonQuest/event.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "common.h"
 #include "event_type.h"
 #include "event_args.h"
 

--- a/CDargonQuest/event_args.h
+++ b/CDargonQuest/event_args.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#define MAX_EVENT_ARGS 4
+#include "common.h"
 
 typedef struct
 {

--- a/CDargonQuest/event_queue.h
+++ b/CDargonQuest/event_queue.h
@@ -1,11 +1,7 @@
 #pragma once
 
-#include <stdarg.h>
-
 #include "common.h"
 #include "event.h"
-
-#define MAX_EVENTS 100
 
 typedef struct
 {

--- a/CDargonQuest/event_type.h
+++ b/CDargonQuest/event_type.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "common.h"
+
 typedef enum
 {
    dqEventStart,

--- a/CDargonQuest/game.c
+++ b/CDargonQuest/game.c
@@ -1,4 +1,5 @@
 #include "game.h"
+#include "menu.h"
 #include "render_config.h"
 #include "window.h"
 #include "clock.h"
@@ -13,17 +14,7 @@ void dqGame_Init()
    dqGame->isRunning = sfFalse;
    dqGame->state = dqStateInit;
 
-   dqGame->titleMenu = (dqMenu_t*)malloc( sizeof( dqMenu_t ) );
-#pragma warning ( suppress:6011 )
-   dqGame->titleMenu->optionCount = 2;
-   dqGame->titleMenu->selectedOption = 0;
-   dqGame->titleMenu->options = (dqMenuOption_t*)malloc( sizeof( dqMenuOption_t ) * dqGame->titleMenu->optionCount );
-#pragma warning ( suppress:6011 )
-   dqGame->titleMenu->options[0].text = STR_TITLE_MENU_START;
-   dqGame->titleMenu->options[0].eventType = dqEventStart;
-   dqGame->titleMenu->options[1].text = STR_TITLE_MENU_QUIT;
-   dqGame->titleMenu->options[1].eventType = dqEventQuit;
-
+   dqMenu_Init();
    dqRenderConfig_Init();
    dqWindow_Init();
    dqRenderer_Init();
@@ -38,9 +29,8 @@ void dqGame_Cleanup()
    dqRenderer_Cleanup();
    dqWindow_Cleanup();
    dqRenderConfig_Cleanup();
+   dqMenu_Cleanup();
 
-   SAFE_DELETE( dqGame->titleMenu->options );
-   SAFE_DELETE( dqGame->titleMenu );
    SAFE_DELETE( dqGame )
 }
 

--- a/CDargonQuest/game.h
+++ b/CDargonQuest/game.h
@@ -2,14 +2,11 @@
 
 #include "common.h"
 #include "state.h"
-#include "menu.h"
 
 typedef struct
 {
    sfBool isRunning;
    dqState_t state;
-
-   dqMenu_t* titleMenu;
 }
 dqGame_t;
 

--- a/CDargonQuest/menu.c
+++ b/CDargonQuest/menu.c
@@ -1,5 +1,25 @@
 #include "menu.h"
 
+void dqMenu_Init()
+{
+   dqTitleMenu = (dqMenu_t*)malloc( sizeof( dqMenu_t ) );
+#pragma warning ( suppress:6011 )
+   dqTitleMenu->optionCount = 2;
+   dqTitleMenu->selectedOption = 0;
+   dqTitleMenu->options = (dqMenuOption_t*)malloc( sizeof( dqMenuOption_t ) * dqTitleMenu->optionCount );
+#pragma warning ( suppress:6011 )
+   dqTitleMenu->options[0].text = STR_TITLE_MENU_START;
+   dqTitleMenu->options[0].eventType = dqEventStart;
+   dqTitleMenu->options[1].text = STR_TITLE_MENU_QUIT;
+   dqTitleMenu->options[1].eventType = dqEventQuit;
+}
+
+void dqMenu_Cleanup()
+{
+   SAFE_DELETE( dqTitleMenu->options );
+   SAFE_DELETE( dqTitleMenu );
+}
+
 void dqMenu_ScrollDown( dqMenu_t* menu )
 {
    menu->selectedOption++;

--- a/CDargonQuest/menu.h
+++ b/CDargonQuest/menu.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "common.h"
 #include "menu_option.h"
 
 typedef struct
@@ -9,6 +10,11 @@ typedef struct
    unsigned int selectedOption;
 }
 dqMenu_t;
+
+dqMenu_t* dqTitleMenu;
+
+void dqMenu_Init();
+void dqMenu_Cleanup();
 
 void dqMenu_ScrollDown( dqMenu_t* menu );
 void dqMenu_ScrollUp( dqMenu_t* menu );

--- a/CDargonQuest/menu_option.h
+++ b/CDargonQuest/menu_option.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "common.h"
 #include "event_type.h"
 
 typedef struct

--- a/CDargonQuest/renderer.h
+++ b/CDargonQuest/renderer.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "common.h"
+
 void dqRenderer_Init();
 void dqRenderer_Cleanup();
 void dqRenderer_Render();

--- a/CDargonQuest/state.h
+++ b/CDargonQuest/state.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "common.h"
+
 typedef enum
 {
    dqStateInit,

--- a/CDargonQuest/title_input_handler.c
+++ b/CDargonQuest/title_input_handler.c
@@ -2,20 +2,20 @@
 #include "title_input_handler.h"
 #include "input_state.h"
 #include "event_queue.h"
-#include "game.h"
+#include "menu.h"
 
 void dqTitleInputHandler_HandleInput()
 {
    if ( dqInputState_WasKeyPressed( sfKeyDown ) )
    {
-      dqMenu_ScrollDown( dqGame->titleMenu );
+      dqMenu_ScrollDown( dqTitleMenu );
    }
    else if ( dqInputState_WasKeyPressed( sfKeyUp ) )
    {
-      dqMenu_ScrollUp( dqGame->titleMenu );
+      dqMenu_ScrollUp( dqTitleMenu );
    }
    else if ( dqInputState_WasKeyPressed( sfKeyReturn ) )
    {
-      dqEventQueue_Push( dqGame->titleMenu->options[dqGame->titleMenu->selectedOption].eventType );
+      dqEventQueue_Push( dqTitleMenu->options[dqTitleMenu->selectedOption].eventType );
    }
 }

--- a/CDargonQuest/title_input_handler.c
+++ b/CDargonQuest/title_input_handler.c
@@ -1,4 +1,3 @@
-#include "common.h"
 #include "title_input_handler.h"
 #include "input_state.h"
 #include "event_queue.h"

--- a/CDargonQuest/title_input_handler.h
+++ b/CDargonQuest/title_input_handler.h
@@ -1,3 +1,5 @@
 #pragma once
 
+#include "common.h"
+
 void dqTitleInputHandler_HandleInput();

--- a/CDargonQuest/title_renderer.c
+++ b/CDargonQuest/title_renderer.c
@@ -1,7 +1,7 @@
 #include "title_renderer.h"
 #include "render_config.h"
 #include "window.h"
-#include "game.h"
+#include "menu.h"
 #include "clock.h"
 
 void dqTitleRenderer_Init()
@@ -29,7 +29,7 @@ void dqTitleRenderer_Init()
 
    dqTitleRenderer->showCarat = sfTrue;
    dqTitleRenderer->caratElapsedSeconds = 0;
-   dqTitleRenderer->selectedOptionCache = dqGame->titleMenu->selectedOption;
+   dqTitleRenderer->selectedOptionCache = dqTitleMenu->selectedOption;
 }
 
 void dqTitleRenderer_Cleanup()
@@ -45,11 +45,11 @@ void dqTitleRenderer_Render()
 {
    unsigned int i;
 
-   if ( dqGame->titleMenu->selectedOption != dqTitleRenderer->selectedOptionCache )
+   if ( dqTitleMenu->selectedOption != dqTitleRenderer->selectedOptionCache )
    {
       dqTitleRenderer->showCarat = sfTrue;
       dqTitleRenderer->caratElapsedSeconds = 0;
-      dqTitleRenderer->selectedOptionCache = dqGame->titleMenu->selectedOption;
+      dqTitleRenderer->selectedOptionCache = dqTitleMenu->selectedOption;
    }
    else
    {
@@ -62,7 +62,7 @@ void dqTitleRenderer_Render()
       }
    }
 
-   for ( i = 0; i < dqGame->titleMenu->optionCount; i++ )
+   for ( i = 0; i < dqTitleMenu->optionCount; i++ )
    {
       if ( dqTitleRenderer->showCarat && dqTitleRenderer->selectedOptionCache == i )
       {
@@ -74,7 +74,7 @@ void dqTitleRenderer_Render()
 
       dqTitleRenderer->menuTextPosition.y = dqRenderConfig->titleMenuOffsetY + ( i * dqTitleRenderer->menuLineSpacing );
       sfText_setPosition( dqTitleRenderer->menuText, dqTitleRenderer->menuTextPosition );
-      sfText_setString( dqTitleRenderer->menuText, dqGame->titleMenu->options[i].text );
+      sfText_setString( dqTitleRenderer->menuText, dqTitleMenu->options[i].text );
 
       sfRenderWindow_drawText( dqWindow, dqTitleRenderer->menuText, NULL );
    }


### PR DESCRIPTION
## Overview

Everything else is global, it doesn't really make sense for the menus to be part of the game object. All of this might change later, but for consistency this PR makes the title menu global.

BONUS: I think it should be the norm to have all headers include common.h (except for error.h and strings.h).