### PR TITLE
Add diagnostics view

### DIFF
--- a/CDargonQuest/CDargonQuest.vcxproj
+++ b/CDargonQuest/CDargonQuest.vcxproj
@@ -161,6 +161,7 @@ xcopy "$(SolutionDir)CDargonQuest\Resources\Fonts\*.*" "$(OutDir)\Resources\Font
     </PostBuildEvent>
   </ItemDefinitionGroup>
   <ItemGroup>
+    <ClCompile Include="diagnostics_renderer.c" />
     <ClCompile Include="error.c" />
     <ClCompile Include="event.c" />
     <ClCompile Include="event_queue.c" />
@@ -178,6 +179,7 @@ xcopy "$(SolutionDir)CDargonQuest\Resources\Fonts\*.*" "$(OutDir)\Resources\Font
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="common.h" />
+    <ClInclude Include="diagnostics_renderer.h" />
     <ClInclude Include="error.h" />
     <ClInclude Include="event.h" />
     <ClInclude Include="event_args.h" />

--- a/CDargonQuest/clock.c
+++ b/CDargonQuest/clock.c
@@ -72,3 +72,13 @@ void dqClock_EndFrame()
    dqClock->lastFrameSeconds = ( GetTickCount64() - dqClock->frameStart ) / 1000.0f;
    dqClock->totalSeconds += dqClock->lastFrameSeconds;
 }
+
+unsigned int dqClock_CurrentFrameRate()
+{
+   return (unsigned int)( 1 / dqClock->lastFrameSeconds );
+}
+
+unsigned int dqClock_AverageFrameRate()
+{
+   return dqClock->frameCount == 0 ? 0 : (unsigned int)( 1 / ( dqClock->totalSeconds / dqClock->frameCount ) );
+}

--- a/CDargonQuest/clock.h
+++ b/CDargonQuest/clock.h
@@ -26,3 +26,5 @@ void dqClock_Init();
 void dqClock_Cleanup();
 void dqClock_StartFrame();
 void dqClock_EndFrame();
+unsigned int dqClock_CurrentFrameRate();
+unsigned int dqClock_AverageFrameRate();

--- a/CDargonQuest/diagnostics_renderer.c
+++ b/CDargonQuest/diagnostics_renderer.c
@@ -1,0 +1,105 @@
+#include "diagnostics_renderer.h"
+#include "render_config.h"
+#include "window.h"
+#include "clock.h"
+
+void dqDiagnosticsRenderer_Init()
+{
+   sfVector2f backgroundSize = { dqRenderConfig->diagnosticsWidth, dqRenderConfig->diagnosticsHeight };
+   sfVector2f backgroundPosition = { dqRenderConfig->windowWidth - dqRenderConfig->diagnosticsWidth, 0 };
+
+   dqDiagnosticsRenderer = (dqDiagnosticsRenderer_t*)malloc( sizeof( dqDiagnosticsRenderer_t ) );
+
+#pragma warning ( suppress:6011 )
+   dqDiagnosticsRenderer->textLine = (char*)calloc( sizeof( char ), dqRenderConfig->diagnosticsLineWidth );
+
+   dqDiagnosticsRenderer->background = sfRectangleShape_create();
+   sfRectangleShape_setSize( dqDiagnosticsRenderer->background, backgroundSize );
+   sfRectangleShape_setPosition( dqDiagnosticsRenderer->background, backgroundPosition );
+   sfRectangleShape_setFillColor( dqDiagnosticsRenderer->background, dqRenderConfig->diagnosticsBackgroundColor );
+
+   dqDiagnosticsRenderer->font = sfFont_createFromFile( dqRenderConfig->diagnosticsFontFilePath );
+
+   dqDiagnosticsRenderer->textPosition.x = dqRenderConfig->windowWidth - dqRenderConfig->diagnosticsWidth + dqRenderConfig->diagnosticsPadding;
+
+   dqDiagnosticsRenderer->text = sfText_create();
+   sfText_setFont( dqDiagnosticsRenderer->text, dqDiagnosticsRenderer->font );
+   sfText_setCharacterSize( dqDiagnosticsRenderer->text, dqRenderConfig->diagnosticsFontSize );
+   sfText_setFillColor( dqDiagnosticsRenderer->text, dqRenderConfig->diagnosticsFontColor );
+
+   dqDiagnosticsRenderer->lineSpacing = sfFont_getLineSpacing( dqDiagnosticsRenderer->font,
+                                                               sfText_getCharacterSize( dqDiagnosticsRenderer->text ) );
+}
+
+void dqDiagnosticsRenderer_Cleanup()
+{
+   sfText_destroy( dqDiagnosticsRenderer->text );
+   sfFont_destroy( dqDiagnosticsRenderer->font );
+
+   SAFE_DELETE( dqDiagnosticsRenderer );
+}
+
+void dqDiagnosticsRenderer_Render()
+{
+   sfRenderWindow_drawRectangleShape( dqWindow, dqDiagnosticsRenderer->background, NULL );
+
+   dqDiagnosticsRenderer->textPosition.y = dqRenderConfig->diagnosticsPadding;
+   sfText_setPosition( dqDiagnosticsRenderer->text, dqDiagnosticsRenderer->textPosition );
+   sprintf_s( dqDiagnosticsRenderer->textLine,
+              dqRenderConfig->diagnosticsLineWidth,
+              "%s%d",
+              STR_DIAGNOSTICS_MAX_FRAME_RATE,
+              dqRenderConfig->maxFrameRate );
+   sfText_setString( dqDiagnosticsRenderer->text, dqDiagnosticsRenderer->textLine );
+   sfRenderWindow_drawText( dqWindow, dqDiagnosticsRenderer->text, NULL );
+
+   dqDiagnosticsRenderer->textPosition.y += dqDiagnosticsRenderer->lineSpacing;
+   sfText_setPosition( dqDiagnosticsRenderer->text, dqDiagnosticsRenderer->textPosition );
+   sprintf_s( dqDiagnosticsRenderer->textLine,
+              dqRenderConfig->diagnosticsLineWidth,
+              "%s%d",
+              STR_DIAGNOSTICS_MIN_FRAME_RATE,
+              dqRenderConfig->minFrameRate );
+   sfText_setString( dqDiagnosticsRenderer->text, dqDiagnosticsRenderer->textLine );
+   sfRenderWindow_drawText( dqWindow, dqDiagnosticsRenderer->text, NULL );
+
+   dqDiagnosticsRenderer->textPosition.y += dqDiagnosticsRenderer->lineSpacing;
+   sfText_setPosition( dqDiagnosticsRenderer->text, dqDiagnosticsRenderer->textPosition );
+   sprintf_s( dqDiagnosticsRenderer->textLine,
+              dqRenderConfig->diagnosticsLineWidth,
+              "%s%d",
+              STR_DIAGNOSTICS_CUR_FRAME_RATE,
+              dqClock_CurrentFrameRate() );
+   sfText_setString( dqDiagnosticsRenderer->text, dqDiagnosticsRenderer->textLine );
+   sfRenderWindow_drawText( dqWindow, dqDiagnosticsRenderer->text, NULL );
+
+   dqDiagnosticsRenderer->textPosition.y += dqDiagnosticsRenderer->lineSpacing;
+   sfText_setPosition( dqDiagnosticsRenderer->text, dqDiagnosticsRenderer->textPosition );
+   sprintf_s( dqDiagnosticsRenderer->textLine,
+              dqRenderConfig->diagnosticsLineWidth,
+              "%s%d",
+              STR_DIAGNOSTICS_AVG_FRAME_RATE,
+              dqClock_AverageFrameRate() );
+   sfText_setString( dqDiagnosticsRenderer->text, dqDiagnosticsRenderer->textLine );
+   sfRenderWindow_drawText( dqWindow, dqDiagnosticsRenderer->text, NULL );
+
+   dqDiagnosticsRenderer->textPosition.y += dqDiagnosticsRenderer->lineSpacing;
+   sfText_setPosition( dqDiagnosticsRenderer->text, dqDiagnosticsRenderer->textPosition );
+   sprintf_s( dqDiagnosticsRenderer->textLine,
+              dqRenderConfig->diagnosticsLineWidth,
+              "%s%d",
+              STR_DIAGNOSTICS_TOTAL_FRAMES,
+              dqClock->frameCount );
+   sfText_setString( dqDiagnosticsRenderer->text, dqDiagnosticsRenderer->textLine );
+   sfRenderWindow_drawText( dqWindow, dqDiagnosticsRenderer->text, NULL );
+
+   dqDiagnosticsRenderer->textPosition.y += dqDiagnosticsRenderer->lineSpacing;
+   sfText_setPosition( dqDiagnosticsRenderer->text, dqDiagnosticsRenderer->textPosition );
+   sprintf_s( dqDiagnosticsRenderer->textLine,
+              dqRenderConfig->diagnosticsLineWidth,
+              "%s%d",
+              STR_DIAGNOSTICS_LAG_FRAMES,
+              dqClock->lagFrameCount );
+   sfText_setString( dqDiagnosticsRenderer->text, dqDiagnosticsRenderer->textLine );
+   sfRenderWindow_drawText( dqWindow, dqDiagnosticsRenderer->text, NULL );
+}

--- a/CDargonQuest/diagnostics_renderer.c
+++ b/CDargonQuest/diagnostics_renderer.c
@@ -29,6 +29,9 @@ void dqDiagnosticsRenderer_Init()
 
    dqDiagnosticsRenderer->lineSpacing = sfFont_getLineSpacing( dqDiagnosticsRenderer->font,
                                                                sfText_getCharacterSize( dqDiagnosticsRenderer->text ) );
+
+   dqDiagnosticsRenderer->currentFrameRateCache = 0;
+   dqDiagnosticsRenderer->currentFrameRateElapsedSeconds = 0;
 }
 
 void dqDiagnosticsRenderer_Cleanup()
@@ -41,6 +44,14 @@ void dqDiagnosticsRenderer_Cleanup()
 
 void dqDiagnosticsRenderer_Render()
 {
+   dqDiagnosticsRenderer->currentFrameRateElapsedSeconds += dqClock->lastFrameSeconds;
+
+   if ( dqDiagnosticsRenderer->currentFrameRateElapsedSeconds >= dqRenderConfig->diagnosticsCurrentFrameRateRefreshRate )
+   {
+      dqDiagnosticsRenderer->currentFrameRateCache = dqClock_CurrentFrameRate();
+      dqDiagnosticsRenderer->currentFrameRateElapsedSeconds = 0;
+   }
+
    sfRenderWindow_drawRectangleShape( dqWindow, dqDiagnosticsRenderer->background, NULL );
 
    dqDiagnosticsRenderer->textPosition.y = dqRenderConfig->diagnosticsPadding;
@@ -69,7 +80,7 @@ void dqDiagnosticsRenderer_Render()
               dqRenderConfig->diagnosticsLineWidth,
               "%s%d",
               STR_DIAGNOSTICS_CUR_FRAME_RATE,
-              dqClock_CurrentFrameRate() );
+              dqDiagnosticsRenderer->currentFrameRateCache );
    sfText_setString( dqDiagnosticsRenderer->text, dqDiagnosticsRenderer->textLine );
    sfRenderWindow_drawText( dqWindow, dqDiagnosticsRenderer->text, NULL );
 

--- a/CDargonQuest/diagnostics_renderer.h
+++ b/CDargonQuest/diagnostics_renderer.h
@@ -1,0 +1,20 @@
+#pragma once
+
+#include "common.h"
+
+typedef struct
+{
+   char* textLine;
+   sfRectangleShape* background;
+   sfFont* font;
+   sfText* text;
+   sfVector2f textPosition;
+   float lineSpacing;
+}
+dqDiagnosticsRenderer_t;
+
+dqDiagnosticsRenderer_t* dqDiagnosticsRenderer;
+
+void dqDiagnosticsRenderer_Init();
+void dqDiagnosticsRenderer_Cleanup();
+void dqDiagnosticsRenderer_Render();

--- a/CDargonQuest/diagnostics_renderer.h
+++ b/CDargonQuest/diagnostics_renderer.h
@@ -10,6 +10,8 @@ typedef struct
    sfText* text;
    sfVector2f textPosition;
    float lineSpacing;
+   unsigned int currentFrameRateCache;
+   float currentFrameRateElapsedSeconds;
 }
 dqDiagnosticsRenderer_t;
 

--- a/CDargonQuest/input_handler.c
+++ b/CDargonQuest/input_handler.c
@@ -1,9 +1,16 @@
 #include "input_handler.h"
+#include "input_state.h"
+#include "render_config.h"
 #include "title_input_handler.h"
 #include "game.h"
 
 void dqInputHandler_HandleInput()
 {
+   if ( dqInputState_WasKeyPressed( sfKeyF8 ) )
+   {
+      dqRenderConfig->showDiagnostics = dqRenderConfig->showDiagnostics ? sfFalse : sfTrue;
+   }
+
    switch ( dqGame->state )
    {
       case dqStateTitle:

--- a/CDargonQuest/render_config.c
+++ b/CDargonQuest/render_config.c
@@ -15,6 +15,13 @@ void dqRenderConfig_Init()
    dqRenderConfig->windowClearColor = sfBlack;
 
    dqRenderConfig->showDiagnostics = sfFalse;
+   dqRenderConfig->diagnosticsFontFilePath = "Resources/Fonts/Consolas.ttf";
+   dqRenderConfig->diagnosticsFontSize = 24;
+   dqRenderConfig->diagnosticsFontColor = sfWhite;
+   dqRenderConfig->diagnosticsBackgroundColor = sfBlue;
+   dqRenderConfig->diagnosticsWidth = 400;
+   dqRenderConfig->diagnosticsHeight = 208;
+   dqRenderConfig->diagnosticsPadding = 18;
 
    dqRenderConfig->menuFontFilePath = "Resources/Fonts/Consolas.ttf";
    dqRenderConfig->menuFontSize = 50;

--- a/CDargonQuest/render_config.c
+++ b/CDargonQuest/render_config.c
@@ -23,6 +23,7 @@ void dqRenderConfig_Init()
    dqRenderConfig->diagnosticsHeight = 208;
    dqRenderConfig->diagnosticsPadding = 18;
    dqRenderConfig->diagnosticsLineWidth = 40;
+   dqRenderConfig->diagnosticsCurrentFrameRateRefreshRate = 0.25f;
 
    dqRenderConfig->menuFontFilePath = "Resources/Fonts/Consolas.ttf";
    dqRenderConfig->menuFontSize = 50;

--- a/CDargonQuest/render_config.c
+++ b/CDargonQuest/render_config.c
@@ -22,6 +22,7 @@ void dqRenderConfig_Init()
    dqRenderConfig->diagnosticsWidth = 400;
    dqRenderConfig->diagnosticsHeight = 208;
    dqRenderConfig->diagnosticsPadding = 18;
+   dqRenderConfig->diagnosticsLineWidth = 40;
 
    dqRenderConfig->menuFontFilePath = "Resources/Fonts/Consolas.ttf";
    dqRenderConfig->menuFontSize = 50;

--- a/CDargonQuest/render_config.c
+++ b/CDargonQuest/render_config.c
@@ -14,6 +14,8 @@ void dqRenderConfig_Init()
    dqRenderConfig->windowStyle = sfTitlebar | sfClose;
    dqRenderConfig->windowClearColor = sfBlack;
 
+   dqRenderConfig->showDiagnostics = sfFalse;
+
    dqRenderConfig->menuFontFilePath = "Resources/Fonts/Consolas.ttf";
    dqRenderConfig->menuFontSize = 50;
    dqRenderConfig->menuFontColor = sfWhite;

--- a/CDargonQuest/render_config.h
+++ b/CDargonQuest/render_config.h
@@ -13,6 +13,8 @@ typedef struct
    sfUint32 windowStyle;
    sfColor windowClearColor;
 
+   sfBool showDiagnostics;
+
    const char* menuFontFilePath;
    unsigned int menuFontSize;
    sfColor menuFontColor;

--- a/CDargonQuest/render_config.h
+++ b/CDargonQuest/render_config.h
@@ -14,6 +14,13 @@ typedef struct
    sfColor windowClearColor;
 
    sfBool showDiagnostics;
+   const char* diagnosticsFontFilePath;
+   unsigned int diagnosticsFontSize;
+   sfColor diagnosticsFontColor;
+   sfColor diagnosticsBackgroundColor;
+   float diagnosticsWidth;
+   float diagnosticsHeight;
+   float diagnosticsPadding;
 
    const char* menuFontFilePath;
    unsigned int menuFontSize;

--- a/CDargonQuest/render_config.h
+++ b/CDargonQuest/render_config.h
@@ -22,6 +22,7 @@ typedef struct
    float diagnosticsHeight;
    float diagnosticsPadding;
    unsigned int diagnosticsLineWidth;
+   float diagnosticsCurrentFrameRateRefreshRate;
 
    const char* menuFontFilePath;
    unsigned int menuFontSize;

--- a/CDargonQuest/render_config.h
+++ b/CDargonQuest/render_config.h
@@ -21,6 +21,7 @@ typedef struct
    float diagnosticsWidth;
    float diagnosticsHeight;
    float diagnosticsPadding;
+   unsigned int diagnosticsLineWidth;
 
    const char* menuFontFilePath;
    unsigned int menuFontSize;

--- a/CDargonQuest/renderer.c
+++ b/CDargonQuest/renderer.c
@@ -1,17 +1,20 @@
 #include "renderer.h"
 #include "window.h"
 #include "render_config.h"
+#include "diagnostics_renderer.h"
 #include "title_renderer.h"
 #include "game.h"
 
 void dqRenderer_Init()
 {
+   dqDiagnosticsRenderer_Init();
    dqTitleRenderer_Init();
 }
 
 void dqRenderer_Cleanup()
 {
    dqTitleRenderer_Cleanup();
+   dqDiagnosticsRenderer_Cleanup();
 }
 
 void dqRenderer_Render()
@@ -23,6 +26,11 @@ void dqRenderer_Render()
       case dqStateTitle:
          dqTitleRenderer_Render();
          break;
+   }
+
+   if ( dqRenderConfig->showDiagnostics )
+   {
+      dqDiagnosticsRenderer_Render();
    }
 
    sfRenderWindow_display( dqWindow );

--- a/CDargonQuest/strings.h
+++ b/CDargonQuest/strings.h
@@ -10,6 +10,13 @@
 
 #define STR_WINDOW_TITLE                  "Dargon Quest"
 
+#define STR_DIAGNOSTICS_MAX_FRAME_RATE    "Maximum Frame Rate: "
+#define STR_DIAGNOSTICS_MIN_FRAME_RATE    "Minimum Frame Rate: "
+#define STR_DIAGNOSTICS_CUR_FRAME_RATE    "Current Frame Rate: "
+#define STR_DIAGNOSTICS_AVG_FRAME_RATE    "Average Frame Rate: "
+#define STR_DIAGNOSTICS_TOTAL_FRAMES      "Total Frames:       "
+#define STR_DIAGNOSTICS_LAG_FRAMES        "Lag Frames:         "
+
 #define STR_TITLE_MENU_START              "Start"
 #define STR_TITLE_MENU_QUIT               "Quit"
 


### PR DESCRIPTION
## Overview

This adds some diagnostics to the upper-right when you press F8. Normally I would use F12, but for some reason this particular project doesn't jive well with that, I guess it interferes with Visual Studio's debug keys. I honestly have no idea why this is not a problem in C++.