### PR TITLE
Refresh diagnostic values on a timer

### DIFF
--- a/CDargonQuest/diagnostics_renderer.c
+++ b/CDargonQuest/diagnostics_renderer.c
@@ -31,7 +31,8 @@ void dqDiagnosticsRenderer_Init()
                                                                sfText_getCharacterSize( dqDiagnosticsRenderer->text ) );
 
    dqDiagnosticsRenderer->currentFrameRateCache = 0;
-   dqDiagnosticsRenderer->currentFrameRateElapsedSeconds = 0;
+   dqDiagnosticsRenderer->averageFrameRateCache = 0;
+   dqDiagnosticsRenderer->refreshElapsedSeconds = 0;
 }
 
 void dqDiagnosticsRenderer_Cleanup()
@@ -44,12 +45,13 @@ void dqDiagnosticsRenderer_Cleanup()
 
 void dqDiagnosticsRenderer_Render()
 {
-   dqDiagnosticsRenderer->currentFrameRateElapsedSeconds += dqClock->lastFrameSeconds;
+   dqDiagnosticsRenderer->refreshElapsedSeconds += dqClock->lastFrameSeconds;
 
-   if ( dqDiagnosticsRenderer->currentFrameRateElapsedSeconds >= dqRenderConfig->diagnosticsCurrentFrameRateRefreshRate )
+   if ( dqDiagnosticsRenderer->refreshElapsedSeconds >= dqRenderConfig->diagnosticsRefreshRate )
    {
       dqDiagnosticsRenderer->currentFrameRateCache = dqClock_CurrentFrameRate();
-      dqDiagnosticsRenderer->currentFrameRateElapsedSeconds = 0;
+      dqDiagnosticsRenderer->averageFrameRateCache = dqClock_AverageFrameRate();
+      dqDiagnosticsRenderer->refreshElapsedSeconds = 0;
    }
 
    sfRenderWindow_drawRectangleShape( dqWindow, dqDiagnosticsRenderer->background, NULL );
@@ -90,7 +92,7 @@ void dqDiagnosticsRenderer_Render()
               dqRenderConfig->diagnosticsLineWidth,
               "%s%d",
               STR_DIAGNOSTICS_AVG_FRAME_RATE,
-              dqClock_AverageFrameRate() );
+              dqDiagnosticsRenderer->averageFrameRateCache );
    sfText_setString( dqDiagnosticsRenderer->text, dqDiagnosticsRenderer->textLine );
    sfRenderWindow_drawText( dqWindow, dqDiagnosticsRenderer->text, NULL );
 

--- a/CDargonQuest/diagnostics_renderer.h
+++ b/CDargonQuest/diagnostics_renderer.h
@@ -11,7 +11,8 @@ typedef struct
    sfVector2f textPosition;
    float lineSpacing;
    unsigned int currentFrameRateCache;
-   float currentFrameRateElapsedSeconds;
+   unsigned int averageFrameRateCache;
+   float refreshElapsedSeconds;
 }
 dqDiagnosticsRenderer_t;
 

--- a/CDargonQuest/render_config.c
+++ b/CDargonQuest/render_config.c
@@ -23,7 +23,7 @@ void dqRenderConfig_Init()
    dqRenderConfig->diagnosticsHeight = 208;
    dqRenderConfig->diagnosticsPadding = 18;
    dqRenderConfig->diagnosticsLineWidth = 40;
-   dqRenderConfig->diagnosticsCurrentFrameRateRefreshRate = 0.25f;
+   dqRenderConfig->diagnosticsRefreshRate = 0.25f;
 
    dqRenderConfig->menuFontFilePath = "Resources/Fonts/Consolas.ttf";
    dqRenderConfig->menuFontSize = 50;

--- a/CDargonQuest/render_config.h
+++ b/CDargonQuest/render_config.h
@@ -22,7 +22,7 @@ typedef struct
    float diagnosticsHeight;
    float diagnosticsPadding;
    unsigned int diagnosticsLineWidth;
-   float diagnosticsCurrentFrameRateRefreshRate;
+   float diagnosticsRefreshRate;
 
    const char* menuFontFilePath;
    unsigned int menuFontSize;


### PR DESCRIPTION
## Overview

The current frame rate is already being refreshed on a timer in the diagnostic view, but the average frame rate should be as well. This PR makes sure both of them are being updated on the same timer.