### PR TITLE
Added map scrolling

### DIFF
--- a/CDargonQuest/entity_sprite.c
+++ b/CDargonQuest/entity_sprite.c
@@ -42,10 +42,6 @@ void dqEntitySprite_Tick( dqEntitySprite_t* sprite )
    {
       sprite->elapsedFrameSeconds += dqClock->lastFrameSeconds;
    }
-   else
-   {
-      sprite->elapsedFrameSeconds = 0;
-   }
 
    while ( sprite->elapsedFrameSeconds >= sprite->frameTimeThreshold )
    {
@@ -57,8 +53,6 @@ void dqEntitySprite_Tick( dqEntitySprite_t* sprite )
          sprite->currentFrame = 0;
       }
    }
-
-   sfSprite_setPosition( sprite->sprite, sprite->entity->hitBoxPosition );
 
    sprite->textureRect.left = sprite->currentFrame * sprite->textureRect.width;
    sprite->textureRect.top = (int)sprite->entity->direction * sprite->textureRect.height;

--- a/CDargonQuest/game.c
+++ b/CDargonQuest/game.c
@@ -116,7 +116,7 @@ void dqGame_Tick()
    }
    else if ( player->hitBoxPosition.x + player->hitBoxSize.x >= dqGameData->maps[0].width )
    {
-      player->hitBoxPosition.x = dqRenderConfig->screenWidth - player->hitBoxSize.x;
+      player->hitBoxPosition.x = dqGameData->maps[0].width - player->hitBoxSize.x;
       player->centerPosition.x = player->hitBoxPosition.x + ( player->hitBoxSize.x / 2 );
    }
 
@@ -127,7 +127,7 @@ void dqGame_Tick()
    }
    else if ( player->hitBoxPosition.y + player->hitBoxSize.y >= dqGameData->maps[0].height )
    {
-      player->hitBoxPosition.y = dqRenderConfig->screenHeight - player->hitBoxSize.y;
+      player->hitBoxPosition.y = dqGameData->maps[0].height - player->hitBoxSize.y;
       player->centerPosition.y = player->hitBoxPosition.y + ( player->hitBoxSize.y / 2 );
    }
 

--- a/CDargonQuest/game.c
+++ b/CDargonQuest/game.c
@@ -9,6 +9,7 @@
 #include "renderer.h"
 #include "event_queue.h"
 #include "entity.h"
+#include "map.h"
 
 void dqGame_Init()
 {
@@ -113,7 +114,7 @@ void dqGame_Tick()
       player->hitBoxPosition.x = 0;
       player->centerPosition.x = player->hitBoxSize.x / 2;
    }
-   else if ( player->hitBoxPosition.x + player->hitBoxSize.x >= dqRenderConfig->screenWidth )
+   else if ( player->hitBoxPosition.x + player->hitBoxSize.x >= dqGameData->maps[0].width )
    {
       player->hitBoxPosition.x = dqRenderConfig->screenWidth - player->hitBoxSize.x;
       player->centerPosition.x = player->hitBoxPosition.x + ( player->hitBoxSize.x / 2 );
@@ -124,7 +125,7 @@ void dqGame_Tick()
       player->hitBoxPosition.y = 0;
       player->centerPosition.y = player->hitBoxSize.y / 2;
    }
-   else if ( player->hitBoxPosition.y + player->hitBoxSize.y >= dqRenderConfig->screenHeight )
+   else if ( player->hitBoxPosition.y + player->hitBoxSize.y >= dqGameData->maps[0].height )
    {
       player->hitBoxPosition.y = dqRenderConfig->screenHeight - player->hitBoxSize.y;
       player->centerPosition.y = player->hitBoxPosition.y + ( player->hitBoxSize.y / 2 );

--- a/CDargonQuest/game_data.c
+++ b/CDargonQuest/game_data.c
@@ -1,7 +1,7 @@
 #include "game_data.h"
 #include "map_loader.h"
 #include "entity.h"
-#include "render_config.h"
+#include "map.h"
 
 void dqGameData_Init()
 {
@@ -13,8 +13,9 @@ void dqGameData_Init()
    dqGameData->player = (dqEntity_t*)malloc( sizeof( dqEntity_t ) );
    CHECK_MALLOC( dqGameData->player )
 
-   dqGameData->player->centerPosition.x = dqRenderConfig->screenWidth / 2;
-   dqGameData->player->centerPosition.y = dqRenderConfig->screenHeight / 2;
+   // TODO: each map will have entrance and exit points depending on where the player just came from
+   dqGameData->player->centerPosition.x = dqGameData->maps[0].width / 2;
+   dqGameData->player->centerPosition.y = dqGameData->maps[0].height / 2;
    dqGameData->player->hitBoxSize.x = 16;
    dqGameData->player->hitBoxSize.y = 16;
    dqGameData->player->hitBoxPosition.x = dqGameData->player->centerPosition.x - ( dqGameData->player->hitBoxSize.x / 2 );

--- a/CDargonQuest/map.c
+++ b/CDargonQuest/map.c
@@ -1,8 +1,8 @@
 #include "map.h"
 #include "map_tile.h"
 
-dqMapTile_t* dqMap_GetTile( dqMap_t* map, unsigned int x, unsigned int y )
+dqMapTile_t* dqMap_GetTile( dqMap_t* map, unsigned int column, unsigned int row )
 {
-   unsigned int tileIndex = ( y * map->width ) + x;
+   unsigned int tileIndex = ( row * map->columns ) + column;
    return &( map->tiles[tileIndex] );
 }

--- a/CDargonQuest/map.h
+++ b/CDargonQuest/map.h
@@ -8,9 +8,9 @@ typedef struct dqMap_t
 {
    dqMapTile_t* tiles;
    unsigned int tileCount;
-   unsigned int width;
-   unsigned int height;
+   unsigned int columns;
+   unsigned int rows;
 }
 dqMap_t;
 
-dqMapTile_t* dqMap_GetTile( dqMap_t* map, unsigned int x, unsigned int y );
+dqMapTile_t* dqMap_GetTile( dqMap_t* map, unsigned int column, unsigned int row );

--- a/CDargonQuest/map.h
+++ b/CDargonQuest/map.h
@@ -10,6 +10,8 @@ typedef struct dqMap_t
    unsigned int tileCount;
    unsigned int columns;
    unsigned int rows;
+   float width;
+   float height;
 }
 dqMap_t;
 

--- a/CDargonQuest/map_loader.c
+++ b/CDargonQuest/map_loader.c
@@ -2,6 +2,7 @@
 #include "game_data.h"
 #include "map.h"
 #include "map_tile.h"
+#include "render_config.h"
 
 void dqMapLoader_LoadMaps()
 {
@@ -14,6 +15,8 @@ void dqMapLoader_LoadMaps()
 
    dqGameData->maps[0].columns = 30;
    dqGameData->maps[0].rows = 20;
+   dqGameData->maps[0].width = dqGameData->maps[0].columns * dqRenderConfig->tileSize;
+   dqGameData->maps[0].height = dqGameData->maps[0].rows * dqRenderConfig->tileSize;
    dqGameData->maps[0].tileCount = dqGameData->maps[0].columns * dqGameData->maps[0].rows;
    dqGameData->maps[0].tiles = (dqMapTile_t*)malloc( sizeof( dqMapTile_t ) * dqGameData->maps[0].tileCount );
    CHECK_MALLOC( dqGameData->maps[0].tiles )

--- a/CDargonQuest/map_loader.c
+++ b/CDargonQuest/map_loader.c
@@ -13,8 +13,8 @@ void dqMapLoader_LoadMaps()
    dqGameData->maps = (dqMap_t*)malloc( sizeof( dqMap_t ) );
    CHECK_MALLOC( dqGameData->maps )
 
-   dqGameData->maps[0].columns = 30;
-   dqGameData->maps[0].rows = 20;
+   dqGameData->maps[0].columns = 100;
+   dqGameData->maps[0].rows = 60;
    dqGameData->maps[0].width = dqGameData->maps[0].columns * dqRenderConfig->tileSize;
    dqGameData->maps[0].height = dqGameData->maps[0].rows * dqRenderConfig->tileSize;
    dqGameData->maps[0].tileCount = dqGameData->maps[0].columns * dqGameData->maps[0].rows;

--- a/CDargonQuest/map_loader.c
+++ b/CDargonQuest/map_loader.c
@@ -13,8 +13,8 @@ void dqMapLoader_LoadMaps()
    dqGameData->maps = (dqMap_t*)malloc( sizeof( dqMap_t ) );
    CHECK_MALLOC( dqGameData->maps )
 
-   dqGameData->maps[0].columns = 100;
-   dqGameData->maps[0].rows = 60;
+   dqGameData->maps[0].columns = 60;
+   dqGameData->maps[0].rows = 40;
    dqGameData->maps[0].width = dqGameData->maps[0].columns * dqRenderConfig->tileSize;
    dqGameData->maps[0].height = dqGameData->maps[0].rows * dqRenderConfig->tileSize;
    dqGameData->maps[0].tileCount = dqGameData->maps[0].columns * dqGameData->maps[0].rows;

--- a/CDargonQuest/map_loader.c
+++ b/CDargonQuest/map_loader.c
@@ -12,16 +12,16 @@ void dqMapLoader_LoadMaps()
    dqGameData->maps = (dqMap_t*)malloc( sizeof( dqMap_t ) );
    CHECK_MALLOC( dqGameData->maps )
 
-   dqGameData->maps[0].width = 30;
-   dqGameData->maps[0].height = 20;
-   dqGameData->maps[0].tileCount = dqGameData->maps[0].width * dqGameData->maps[0].height;
+   dqGameData->maps[0].columns = 30;
+   dqGameData->maps[0].rows = 20;
+   dqGameData->maps[0].tileCount = dqGameData->maps[0].columns * dqGameData->maps[0].rows;
    dqGameData->maps[0].tiles = (dqMapTile_t*)malloc( sizeof( dqMapTile_t ) * dqGameData->maps[0].tileCount );
    CHECK_MALLOC( dqGameData->maps[0].tiles )
 
    for ( i = 0; i < dqGameData->maps[0].tileCount; i++ )
    {
       // this makes a checkerboard
-      if ( i % dqGameData->maps[0].width == 0 )
+      if ( i % dqGameData->maps[0].columns == 0 )
       {
          idTemp = id1;
          id1 = id2;

--- a/CDargonQuest/overworld_renderer.c
+++ b/CDargonQuest/overworld_renderer.c
@@ -9,7 +9,25 @@
 
 void dqOverworldRenderer_Init()
 {
+   int i;
+
    sfVector2f tileSize = { dqRenderConfig->tileSize, dqRenderConfig->tileSize };
+
+   sfVector2f occlusionSize0 = { dqRenderConfig->overworldViewOffset.x, dqRenderConfig->screenHeight };
+   sfVector2f occlusionPos0 = { 0, 0 };
+
+   sfVector2f occlusionSize1 = { dqRenderConfig->screenWidth - occlusionSize0.x, dqRenderConfig->overworldViewOffset.y };
+   sfVector2f occlusionPos1 = { occlusionSize0.x, 0 };
+
+   sfVector2f occlusionSize2 = {
+      dqRenderConfig->screenWidth - occlusionSize0.x - dqRenderConfig->overworldViewSize.x,
+      dqRenderConfig->screenHeight - occlusionSize1.y };
+   sfVector2f occlusionPos2 = { occlusionSize0.x + dqRenderConfig->overworldViewSize.x, occlusionSize1.y };
+
+   sfVector2f occlusionSize3 = {
+      dqRenderConfig->screenWidth - occlusionSize0.x - occlusionSize2.x,
+      dqRenderConfig->screenHeight - occlusionSize1.y - dqRenderConfig->overworldViewSize.y };
+   sfVector2f occlusionPos3 = { occlusionSize0.x, occlusionSize1.y + dqRenderConfig->overworldViewSize.y };
 
    dqOverworldRenderer = (dqOverworldRenderer_t*)malloc( sizeof( dqOverworldRenderer_t ) );
    CHECK_MALLOC( dqOverworldRenderer )
@@ -21,10 +39,35 @@ void dqOverworldRenderer_Init()
    dqOverworldRenderer->lightTile = sfRectangleShape_create();
    sfRectangleShape_setSize( dqOverworldRenderer->lightTile, tileSize );
    sfRectangleShape_setFillColor( dqOverworldRenderer->lightTile, sfColor_fromRGB( 224, 224, 224 ) );
+
+   for ( i = 0; i < 4; i++ )
+   {
+      dqOverworldRenderer->occlusions[i] = sfRectangleShape_create();
+      sfRectangleShape_setFillColor( dqOverworldRenderer->occlusions[i], dqRenderConfig->windowClearColor );
+   }
+
+   sfRectangleShape_setSize( dqOverworldRenderer->occlusions[0], occlusionSize0 );
+   sfRectangleShape_setPosition( dqOverworldRenderer->occlusions[0], occlusionPos0 );
+
+   sfRectangleShape_setSize( dqOverworldRenderer->occlusions[1], occlusionSize1 );
+   sfRectangleShape_setPosition( dqOverworldRenderer->occlusions[1], occlusionPos1 );
+
+   sfRectangleShape_setSize( dqOverworldRenderer->occlusions[2], occlusionSize2 );
+   sfRectangleShape_setPosition( dqOverworldRenderer->occlusions[2], occlusionPos2 );
+
+   sfRectangleShape_setSize( dqOverworldRenderer->occlusions[3], occlusionSize3 );
+   sfRectangleShape_setPosition( dqOverworldRenderer->occlusions[3], occlusionPos3 );
 }
 
 void dqOverworldRenderer_Cleanup()
 {
+   int i;
+
+   for ( i = 0; i < 4; i++ )
+   {
+      sfRectangleShape_destroy( dqOverworldRenderer->occlusions[i] );
+   }
+
    sfRectangleShape_destroy( dqOverworldRenderer->darkTile );
    sfRectangleShape_destroy( dqOverworldRenderer->lightTile );
 
@@ -47,58 +90,58 @@ void dqOverworldRenderer_RenderMap()
    dqMapTile_t* tile;
    sfRectangleShape* rect;
 
-   if ( map->width < dqRenderConfig->screenWidth )
+   if ( map->width < dqRenderConfig->overworldViewSize.x )
    {
       viewOffset->x = 0;
-      sideOffset->x = ( dqRenderConfig->screenWidth / 2 ) - ( map->width / 2 );
+      sideOffset->x = ( dqRenderConfig->overworldViewSize.x / 2 ) - ( map->width / 2 );
       tileOffsetX = 0;
       startTileColumn = 0;
       endTileColumn = map->columns - 1;
    }
    else
    {
-      viewOffset->x = dqGameData->player->centerPosition.x - ( dqRenderConfig->screenWidth / 2 );
+      viewOffset->x = dqGameData->player->centerPosition.x - ( dqRenderConfig->overworldViewSize.x / 2 );
       sideOffset->x = 0;
 
       if ( viewOffset->x < 0 )
       {
          viewOffset->x = 0;
       }
-      else if ( ( viewOffset->x + dqRenderConfig->screenWidth ) >= map->width )
+      else if ( ( viewOffset->x + dqRenderConfig->overworldViewSize.x ) >= map->width )
       {
-         viewOffset->x = map->width - dqRenderConfig->screenWidth;
+         viewOffset->x = map->width - dqRenderConfig->overworldViewSize.x;
       }
 
       tileOffsetX = (float)( (unsigned int)viewOffset->x % (unsigned int)dqRenderConfig->tileSize );
       startTileColumn = (unsigned int)( viewOffset->x / dqRenderConfig->tileSize );
-      endTileColumn = (unsigned int)( ( viewOffset->x + dqRenderConfig->screenWidth ) / dqRenderConfig->tileSize );
+      endTileColumn = (unsigned int)( ( viewOffset->x + dqRenderConfig->overworldViewSize.x ) / dqRenderConfig->tileSize );
    }
 
-   if ( map->height < dqRenderConfig->screenHeight )
+   if ( map->height < dqRenderConfig->overworldViewSize.y )
    {
       viewOffset->y = 0;
-      sideOffset->y = ( dqRenderConfig->screenHeight / 2 ) - ( map->height / 2 );
+      sideOffset->y = ( dqRenderConfig->overworldViewSize.y / 2 ) - ( map->height / 2 );
       tileOffsetY = 0;
       startTileRow = 0;
       endTileRow = map->rows - 1;
    }
    else
    {
-      viewOffset->y = dqGameData->player->centerPosition.y - ( dqRenderConfig->screenHeight / 2 );
+      viewOffset->y = dqGameData->player->centerPosition.y - ( dqRenderConfig->overworldViewSize.y / 2 );
       sideOffset->y = 0;
 
       if ( viewOffset->y < 0 )
       {
          viewOffset->y = 0;
       }
-      else if ( ( viewOffset->y + dqRenderConfig->screenHeight ) >= map->height )
+      else if ( ( viewOffset->y + dqRenderConfig->overworldViewSize.y ) >= map->height )
       {
-         viewOffset->y = map->height - dqRenderConfig->screenHeight;
+         viewOffset->y = map->height - dqRenderConfig->overworldViewSize.y;
       }
 
       tileOffsetY = (float)( (unsigned int)viewOffset->y % (unsigned int)dqRenderConfig->tileSize );
       startTileRow = (unsigned int)( viewOffset->y / dqRenderConfig->tileSize );
-      endTileRow = (unsigned int)( ( viewOffset->y + dqRenderConfig->screenHeight ) / dqRenderConfig->tileSize );
+      endTileRow = (unsigned int)( ( viewOffset->y + dqRenderConfig->overworldViewSize.y ) / dqRenderConfig->tileSize );
    }
 
    for ( i = 0, row = startTileRow; row <= endTileRow; row++, i++ )
@@ -108,12 +151,17 @@ void dqOverworldRenderer_RenderMap()
          tile = dqMap_GetTile( map, column, row );
          rect = tile->tileId == 0 ? dqOverworldRenderer->darkTile : dqOverworldRenderer->lightTile;
 
-         dqOverworldRenderer->tilePosition.x = ( j * dqRenderConfig->tileSize ) - tileOffsetX + sideOffset->x;
-         dqOverworldRenderer->tilePosition.y = ( i * dqRenderConfig->tileSize ) - tileOffsetY + sideOffset->y;
+         dqOverworldRenderer->tilePosition.x = ( j * dqRenderConfig->tileSize ) - tileOffsetX + sideOffset->x + dqRenderConfig->overworldViewOffset.x;
+         dqOverworldRenderer->tilePosition.y = ( i * dqRenderConfig->tileSize ) - tileOffsetY + sideOffset->y + dqRenderConfig->overworldViewOffset.y;
 
          sfRectangleShape_setPosition( rect, dqOverworldRenderer->tilePosition );
          dqWindow_DrawRectangleShape( rect );
       }
+   }
+
+   for ( i = 0; i < 4; i++ )
+   {
+      dqWindow_DrawRectangleShape( dqOverworldRenderer->occlusions[i] );
    }
 }
 
@@ -121,8 +169,8 @@ void dqOverworldRenderer_RenderEntities()
 {
    dqEntitySprite_t* playerSprite = dqRenderData->playerSprite;
    sfVector2f position = {
-      playerSprite->entity->hitBoxPosition.x - dqOverworldRenderer->viewOffset.x + dqOverworldRenderer->sideOffset.x,
-      playerSprite->entity->hitBoxPosition.y - dqOverworldRenderer->viewOffset.y + dqOverworldRenderer->sideOffset.y
+      playerSprite->entity->hitBoxPosition.x - dqOverworldRenderer->viewOffset.x + dqOverworldRenderer->sideOffset.x + dqRenderConfig->overworldViewOffset.x,
+      playerSprite->entity->hitBoxPosition.y - dqOverworldRenderer->viewOffset.y + dqOverworldRenderer->sideOffset.y + dqRenderConfig->overworldViewOffset.y
    };
 
    sfSprite_setPosition( playerSprite->sprite, position );

--- a/CDargonQuest/overworld_renderer.c
+++ b/CDargonQuest/overworld_renderer.c
@@ -44,7 +44,7 @@ void dqOverworldRenderer_Render()
 
 void dqOverworldRenderer_RenderMap()
 {
-   unsigned int i = 0, col = 0, row = 0;
+   unsigned int i = 0, column = 0, row = 0;
    dqMap_t* map = &( dqGameData->maps[0] );
    dqMapTile_t* tile;
    sfRectangleShape* rect;
@@ -54,17 +54,17 @@ void dqOverworldRenderer_RenderMap()
       tile = &( map->tiles[i] );
       rect = tile->tileId == 0 ? dqOverworldRenderer->darkTile : dqOverworldRenderer->lightTile;
 
-      dqOverworldRenderer->tilePosition.x = col * dqRenderConfig->tileSize;
+      dqOverworldRenderer->tilePosition.x = column * dqRenderConfig->tileSize;
       dqOverworldRenderer->tilePosition.y = row * dqRenderConfig->tileSize;
 
       sfRectangleShape_setPosition( rect, dqOverworldRenderer->tilePosition );
       dqWindow_DrawRectangleShape( rect );
 
-      col++;
+      column++;
 
-      if ( col >= map->width )
+      if ( column >= map->columns )
       {
-         col = 0;
+         column = 0;
          row++;
       }
    }

--- a/CDargonQuest/overworld_renderer.c
+++ b/CDargonQuest/overworld_renderer.c
@@ -40,44 +40,66 @@ void dqOverworldRenderer_Render()
 void dqOverworldRenderer_RenderMap()
 {
    sfVector2f* viewOffset = &( dqOverworldRenderer->viewOffset );
+   sfVector2f* sideOffset = &( dqOverworldRenderer->sideOffset );
    float tileOffsetX, tileOffsetY;
    unsigned int startTileColumn, startTileRow, endTileColumn, endTileRow, column, row, i, j;
    dqMap_t* map = &( dqGameData->maps[0] );
    dqMapTile_t* tile;
    sfRectangleShape* rect;
 
-   // TODO: consider the cases where the whole map fits in the view either horizontally or vertically.
-
-   viewOffset->x = dqGameData->player->centerPosition.x - ( dqRenderConfig->screenWidth / 2 );
-
-   if ( viewOffset->x < 0 )
+   if ( map->width < dqRenderConfig->screenWidth )
    {
       viewOffset->x = 0;
+      sideOffset->x = ( dqRenderConfig->screenWidth / 2 ) - ( map->width / 2 );
+      tileOffsetX = 0;
+      startTileColumn = 0;
+      endTileColumn = map->columns - 1;
    }
-   else if ( ( viewOffset->x + dqRenderConfig->screenWidth ) >= map->width )
+   else
    {
-      viewOffset->x = map->width - dqRenderConfig->screenWidth;
+      viewOffset->x = dqGameData->player->centerPosition.x - ( dqRenderConfig->screenWidth / 2 );
+      sideOffset->x = 0;
+
+      if ( viewOffset->x < 0 )
+      {
+         viewOffset->x = 0;
+      }
+      else if ( ( viewOffset->x + dqRenderConfig->screenWidth ) >= map->width )
+      {
+         viewOffset->x = map->width - dqRenderConfig->screenWidth;
+      }
+
+      tileOffsetX = (float)( (unsigned int)viewOffset->x % (unsigned int)dqRenderConfig->tileSize );
+      startTileColumn = (unsigned int)( viewOffset->x / dqRenderConfig->tileSize );
+      endTileColumn = (unsigned int)( ( viewOffset->x + dqRenderConfig->screenWidth ) / dqRenderConfig->tileSize );
    }
 
-   viewOffset->y = dqGameData->player->centerPosition.y - ( dqRenderConfig->screenHeight / 2 );
-
-   if ( viewOffset->y < 0 )
+   if ( map->height < dqRenderConfig->screenHeight )
    {
       viewOffset->y = 0;
+      sideOffset->y = ( dqRenderConfig->screenHeight / 2 ) - ( map->height / 2 );
+      tileOffsetY = 0;
+      startTileRow = 0;
+      endTileRow = map->rows - 1;
    }
-   else if ( ( viewOffset->y + dqRenderConfig->screenHeight ) >= map->height )
+   else
    {
-      viewOffset->y = map->height - dqRenderConfig->screenHeight;
+      viewOffset->y = dqGameData->player->centerPosition.y - ( dqRenderConfig->screenHeight / 2 );
+      sideOffset->y = 0;
+
+      if ( viewOffset->y < 0 )
+      {
+         viewOffset->y = 0;
+      }
+      else if ( ( viewOffset->y + dqRenderConfig->screenHeight ) >= map->height )
+      {
+         viewOffset->y = map->height - dqRenderConfig->screenHeight;
+      }
+
+      tileOffsetY = (float)( (unsigned int)viewOffset->y % (unsigned int)dqRenderConfig->tileSize );
+      startTileRow = (unsigned int)( viewOffset->y / dqRenderConfig->tileSize );
+      endTileRow = (unsigned int)( ( viewOffset->y + dqRenderConfig->screenHeight ) / dqRenderConfig->tileSize );
    }
-
-   tileOffsetX = (float)( (unsigned int)viewOffset->x % (unsigned int)dqRenderConfig->tileSize );
-   tileOffsetY = (float)( (unsigned int)viewOffset->y % (unsigned int)dqRenderConfig->tileSize );
-
-   startTileColumn = (unsigned int)( viewOffset->x / dqRenderConfig->tileSize );
-   startTileRow = (unsigned int)( viewOffset->y / dqRenderConfig->tileSize );
-
-   endTileColumn = (unsigned int)( ( viewOffset->x + dqRenderConfig->screenWidth ) / dqRenderConfig->tileSize );
-   endTileRow = (unsigned int)( ( viewOffset->y + dqRenderConfig->screenHeight ) / dqRenderConfig->tileSize );
 
    for ( i = 0, row = startTileRow; row <= endTileRow; row++, i++ )
    {
@@ -86,8 +108,8 @@ void dqOverworldRenderer_RenderMap()
          tile = dqMap_GetTile( map, column, row );
          rect = tile->tileId == 0 ? dqOverworldRenderer->darkTile : dqOverworldRenderer->lightTile;
 
-         dqOverworldRenderer->tilePosition.x = ( j * dqRenderConfig->tileSize ) - tileOffsetX;
-         dqOverworldRenderer->tilePosition.y = ( i * dqRenderConfig->tileSize ) - tileOffsetY;
+         dqOverworldRenderer->tilePosition.x = ( j * dqRenderConfig->tileSize ) - tileOffsetX + sideOffset->x;
+         dqOverworldRenderer->tilePosition.y = ( i * dqRenderConfig->tileSize ) - tileOffsetY + sideOffset->y;
 
          sfRectangleShape_setPosition( rect, dqOverworldRenderer->tilePosition );
          dqWindow_DrawRectangleShape( rect );
@@ -99,8 +121,8 @@ void dqOverworldRenderer_RenderEntities()
 {
    dqEntitySprite_t* playerSprite = dqRenderData->playerSprite;
    sfVector2f position = {
-      playerSprite->entity->hitBoxPosition.x - dqOverworldRenderer->viewOffset.x,
-      playerSprite->entity->hitBoxPosition.y - dqOverworldRenderer->viewOffset.y
+      playerSprite->entity->hitBoxPosition.x - dqOverworldRenderer->viewOffset.x + dqOverworldRenderer->sideOffset.x,
+      playerSprite->entity->hitBoxPosition.y - dqOverworldRenderer->viewOffset.y + dqOverworldRenderer->sideOffset.y
    };
 
    sfSprite_setPosition( playerSprite->sprite, position );

--- a/CDargonQuest/overworld_renderer.h
+++ b/CDargonQuest/overworld_renderer.h
@@ -8,7 +8,7 @@ typedef struct dqOverworldRenderer_t
    sfRectangleShape* lightTile;
    sfVector2f tilePosition;
 
-   sfRectangleShape* entityRect;
+   sfVector2f viewOffset;
 }
 dqOverworldRenderer_t;
 

--- a/CDargonQuest/overworld_renderer.h
+++ b/CDargonQuest/overworld_renderer.h
@@ -9,6 +9,7 @@ typedef struct dqOverworldRenderer_t
    sfVector2f tilePosition;
 
    sfVector2f viewOffset;
+   sfVector2f sideOffset;
 }
 dqOverworldRenderer_t;
 

--- a/CDargonQuest/overworld_renderer.h
+++ b/CDargonQuest/overworld_renderer.h
@@ -10,6 +10,8 @@ typedef struct dqOverworldRenderer_t
 
    sfVector2f viewOffset;
    sfVector2f sideOffset;
+
+   sfRectangleShape* occlusions[4];
 }
 dqOverworldRenderer_t;
 

--- a/CDargonQuest/render_config.c
+++ b/CDargonQuest/render_config.c
@@ -39,6 +39,11 @@ void dqRenderConfig_Init()
 
    dqRenderConfig->tileSize = 16;
 
+   dqRenderConfig->overworldViewSize.x = 448;
+   dqRenderConfig->overworldViewSize.y = 256;
+   dqRenderConfig->overworldViewOffset.x = 16;
+   dqRenderConfig->overworldViewOffset.y = 16;
+
    dqRenderConfig->playerTexturePath = "Resources/Sprites/player.png";
 }
 

--- a/CDargonQuest/render_config.h
+++ b/CDargonQuest/render_config.h
@@ -38,6 +38,9 @@ typedef struct dqRenderConfig_t
 
    float tileSize;
 
+   sfVector2f overworldViewSize;
+   sfVector2f overworldViewOffset;
+
    const char* playerTexturePath;
 }
 dqRenderConfig_t;


### PR DESCRIPTION
## Overview

This PR updates the map and entity rendering code to try and show the player at the center of the screen, and only render the tiles that are in view (you can set the view size independent of the screen size). I took care to take into account the size of the map vs the size of the view, so if the map is smaller than the view it should still work.