### PR TITLE
Fixed caps lock issue

### DIFF
--- a/CDargonQuest/input_state.c
+++ b/CDargonQuest/input_state.c
@@ -32,9 +32,9 @@ void dqInputState_Reset()
 
 void dqInputState_SetKeyPressed( sfKeyCode keyCode )
 {
-   if ( keyCode >= 0 )
+   if ( keyCode >= 0 && keyCode < sfKeyCount )
    {
-      dqInputState->keysPressed[(int)keyCode] = sfTrue;
+      dqInputState->keysPressed[keyCode] = sfTrue;
       dqInputState->keyWasPressed = sfTrue;
       dqInputState->lastPressedKey = keyCode;
    }
@@ -42,20 +42,20 @@ void dqInputState_SetKeyPressed( sfKeyCode keyCode )
 
 void dqInputState_SetKeyReleased( sfKeyCode keyCode )
 {
-   if ( keyCode >= 0 )
+   if ( keyCode >= 0 && keyCode < sfKeyCount )
    {
-      dqInputState->keysReleased[(int)keyCode] = sfTrue;
+      dqInputState->keysReleased[keyCode] = sfTrue;
    }
 }
 
 sfBool dqInputState_WasKeyPressed( sfKeyCode keyCode )
 {
-   return keyCode >= 0 ? dqInputState->keysPressed[keyCode] : sfFalse;
+   return ( keyCode >= 0 && keyCode < sfKeyCount ) ? dqInputState->keysPressed[keyCode] : sfFalse;
 }
 
 sfBool dqInputState_WasKeyReleased( sfKeyCode keyCode )
 {
-   return keyCode >= 0 ? dqInputState->keysReleased[keyCode] : sfFalse;
+   return ( keyCode >= 0 && keyCode < sfKeyCount) ? dqInputState->keysReleased[keyCode] : sfFalse;
 }
 
 sfBool dqInputState_IsKeyDown( sfKeyCode keyCode )

--- a/CDargonQuest/input_state.c
+++ b/CDargonQuest/input_state.c
@@ -20,7 +20,7 @@ void dqInputState_Cleanup()
 
 void dqInputState_Reset()
 {
-   static int i;
+   int i;
 
    for ( i = 0; i < (int)sfKeyCount; i++ )
    {
@@ -32,29 +32,35 @@ void dqInputState_Reset()
 
 void dqInputState_SetKeyPressed( sfKeyCode keyCode )
 {
-   dqInputState->keysPressed[(int)keyCode] = sfTrue;
-   dqInputState->keyWasPressed = sfTrue;
-   dqInputState->lastPressedKey = keyCode;
+   if ( keyCode >= 0 )
+   {
+      dqInputState->keysPressed[(int)keyCode] = sfTrue;
+      dqInputState->keyWasPressed = sfTrue;
+      dqInputState->lastPressedKey = keyCode;
+   }
 }
 
 void dqInputState_SetKeyReleased( sfKeyCode keyCode )
 {
-   dqInputState->keysReleased[(int)keyCode] = sfTrue;
+   if ( keyCode >= 0 )
+   {
+      dqInputState->keysReleased[(int)keyCode] = sfTrue;
+   }
 }
 
 sfBool dqInputState_WasKeyPressed( sfKeyCode keyCode )
 {
-   return dqInputState->keysPressed[keyCode];
+   return keyCode >= 0 ? dqInputState->keysPressed[keyCode] : sfFalse;
 }
 
 sfBool dqInputState_WasKeyReleased( sfKeyCode keyCode )
 {
-   return dqInputState->keysReleased[keyCode];
+   return keyCode >= 0 ? dqInputState->keysReleased[keyCode] : sfFalse;
 }
 
 sfBool dqInputState_IsKeyDown( sfKeyCode keyCode )
 {
-   return sfKeyboard_isKeyPressed( keyCode );
+   return keyCode >= 0 ? sfKeyboard_isKeyPressed( keyCode ) : sfFalse;
 }
 
 sfBool dqInputState_IsAnyKeyDown()


### PR DESCRIPTION
## Overview

Turns out pressing the caps-lock key results in an `sfKeyCode` of -1, which we don't account for anywhere, so it caused a crash. This PR makes sure we always check the key code when it matters.