### PR TITLE
Consolidated map tile cheats

### DIFF
--- a/CDargonQuest/game_config.c
+++ b/CDargonQuest/game_config.c
@@ -13,11 +13,8 @@ void dqGameConfig_Init()
    dqGameConfig->playerVelocityDiagonal = 44;
 
    dqGameConfig->noClipCheat = sfFalse;
-   dqGameConfig->passableCheat = sfFalse;
-   dqGameConfig->mapSwapCheat = sfFalse;
    dqGameConfig->invisibleCheat = sfFalse;
-   dqGameConfig->encounterRateCheat = sfFalse;
-   dqGameConfig->enemyTierCheat = sfFalse;
+   dqGameConfig->tileStatCheat = sfFalse;
 }
 
 void dqGameConfig_Cleanup()

--- a/CDargonQuest/game_config.h
+++ b/CDargonQuest/game_config.h
@@ -12,11 +12,8 @@ typedef struct dqGameConfig_t
    float playerVelocityDiagonal;
 
    sfBool noClipCheat;
-   sfBool passableCheat;
-   sfBool mapSwapCheat;
    sfBool invisibleCheat;
-   sfBool encounterRateCheat;
-   sfBool enemyTierCheat;
+   sfBool tileStatCheat;
 }
 dqGameConfig_t;
 

--- a/CDargonQuest/input_handler.c
+++ b/CDargonQuest/input_handler.c
@@ -23,32 +23,6 @@ static void dqInputHandler_HandleCheat()
          dqLog_Message( "no-clip cheat off" );
       }
    }
-   else if ( !strcmp( cheat, "dqpass" ) )
-   {
-      dqGameConfig->passableCheat = dqGameConfig->passableCheat ? sfFalse : sfTrue;
-
-      if ( dqGameConfig->passableCheat )
-      {
-         dqLog_Message( "passable tiles overlay cheat on" );
-      }
-      else
-      {
-         dqLog_Message( "passable tiles overlay cheat off" );
-      }
-   }
-   else if ( !strcmp( cheat, "dqswap" ) )
-   {
-      dqGameConfig->mapSwapCheat = dqGameConfig->mapSwapCheat ? sfFalse : sfTrue;
-
-      if ( dqGameConfig->mapSwapCheat )
-      {
-         dqLog_Message( "map-swap tiles overlay cheat on" );
-      }
-      else
-      {
-         dqLog_Message( "map-swap tiles overlay cheat off" );
-      }
-   }
    else if ( !strcmp( cheat, "dqinvis" ) )
    {
       dqGameConfig->invisibleCheat = dqGameConfig->invisibleCheat ? sfFalse : sfTrue;
@@ -62,42 +36,24 @@ static void dqInputHandler_HandleCheat()
          dqLog_Message( "invisibility cheat off" );
       }
    }
-   else if ( !strcmp( cheat, "dqenc" ) )
+   else if ( !strcmp( cheat, "dqtilestat" ) )
    {
-      dqGameConfig->encounterRateCheat = dqGameConfig->encounterRateCheat ? sfFalse : sfTrue;
+      dqGameConfig->tileStatCheat = dqGameConfig->tileStatCheat ? sfFalse : sfTrue;
 
-      if ( dqGameConfig->encounterRateCheat )
+      if ( dqGameConfig->tileStatCheat )
       {
-         dqGameConfig->enemyTierCheat = sfFalse;
-         dqLog_Message( "encounter rate overlay cheat on" );
+         dqLog_Message( "map tile stats cheat on" );
       }
       else
       {
-         dqLog_Message( "encounter rate overlay cheat off" );
-      }
-   }
-   else if ( !strcmp( cheat, "dqtier" ) )
-   {
-      dqGameConfig->enemyTierCheat = dqGameConfig->enemyTierCheat ? sfFalse : sfTrue;
-
-      if ( dqGameConfig->enemyTierCheat )
-      {
-         dqGameConfig->encounterRateCheat = sfFalse;
-         dqLog_Message( "enemy tier overlay cheat on" );
-      }
-      else
-      {
-         dqLog_Message( "enemy tier overlay cheat off" );
+         dqLog_Message( "map tile stats cheat off" );
       }
    }
    else if ( !strcmp( cheat, "dqclear" ) )
    {
       dqGameConfig->noClipCheat = sfFalse;
-      dqGameConfig->passableCheat = sfFalse;
-      dqGameConfig->mapSwapCheat = sfFalse;
       dqGameConfig->invisibleCheat = sfFalse;
-      dqGameConfig->encounterRateCheat = sfFalse;
-      dqGameConfig->enemyTierCheat = sfFalse;
+      dqGameConfig->tileStatCheat = sfFalse;
       dqLog_Message( "cleared all cheats" );
    }
 
@@ -106,14 +62,11 @@ static void dqInputHandler_HandleCheat()
 
 static void dqInputHandler_CheckCheats()
 {
-   int cheatStringLength, i, lastIndex, matchCount;
+   int cheatStringLength, i, l, lastIndex, matchCount;
    static const char* cheats[] = {
       "dqclip",
-      "dqpass",
-      "dqswap",
       "dqinvis",
-      "dqenc",
-      "dqtier",
+      "dqtilestat",
       "dqclear"
    };
    static int cheatCount = (int)( sizeof( cheats ) / sizeof( const char* ) );
@@ -133,11 +86,13 @@ static void dqInputHandler_CheckCheats()
 
    for ( i = 0; i < cheatCount; i++ )
    {
-      if ( cheats[i][lastIndex] != dqInputHandler->cheatString[lastIndex] )
+      l = (int)strlen( cheats[i] );
+
+      if ( lastIndex >= l || cheats[i][lastIndex] != dqInputHandler->cheatString[lastIndex] )
       {
          matchCount--;
       }
-      else if ( cheatStringLength == (int)strlen( cheats[i] ) )
+      else if ( cheatStringLength == l && !strcmp( cheats[i], dqInputHandler->cheatString ) )
       {
          dqInputHandler_HandleCheat();
          return;

--- a/CDargonQuest/overworld_renderer.c
+++ b/CDargonQuest/overworld_renderer.c
@@ -72,6 +72,7 @@ void dqOverworldRenderer_Init()
    dqOverworldRenderer->cheatText = sfText_create();
    sfText_setFont( dqOverworldRenderer->cheatText, dqOverworldRenderer->cheatFont );
    sfText_setCharacterSize( dqOverworldRenderer->cheatText, dqRenderConfig->cheatFontSize );
+   sfText_setScale( dqOverworldRenderer->cheatText, dqRenderConfig->cheatFontScale );
    sfText_setLetterSpacing( dqOverworldRenderer->cheatText, dqRenderConfig->cheatLetterSpacing );
    sfText_setFillColor( dqOverworldRenderer->cheatText, dqRenderConfig->cheatFontColor );
 }
@@ -178,9 +179,14 @@ void dqOverworldRenderer_RenderMap()
          sfSprite_setPosition( dqOverworldRenderer->tileSprite, tilePosition );
          dqWindow_DrawSprite( dqOverworldRenderer->tileSprite );
 
-         if ( dqGameConfig->passableCheat )
+         if ( dqGameConfig->tileStatCheat )
          {
-            if ( tile->isPassable )
+            if ( tile->isExit )
+            {
+               sfRectangleShape_setPosition( dqOverworldRenderer->mapSwapRect, tilePosition );
+               dqWindow_DrawRectangleShape( dqOverworldRenderer->mapSwapRect );
+            }
+            else if ( tile->isPassable )
             {
                sfRectangleShape_setPosition( dqOverworldRenderer->passableRect, tilePosition );
                dqWindow_DrawRectangleShape( dqOverworldRenderer->passableRect );
@@ -190,25 +196,8 @@ void dqOverworldRenderer_RenderMap()
                sfRectangleShape_setPosition( dqOverworldRenderer->impassableRect, tilePosition );
                dqWindow_DrawRectangleShape( dqOverworldRenderer->impassableRect );
             }
-         }
 
-         if ( dqGameConfig->mapSwapCheat && tile->isExit )
-         {
-            sfRectangleShape_setPosition( dqOverworldRenderer->mapSwapRect, tilePosition );
-            dqWindow_DrawRectangleShape( dqOverworldRenderer->mapSwapRect );
-         }
-
-         if ( dqGameConfig->encounterRateCheat )
-         {
-            sprintf_s( dqOverworldRenderer->cheatChars, 32, "%d", tile->encounterRate );
-            sfText_setString( dqOverworldRenderer->cheatText, dqOverworldRenderer->cheatChars );
-            sfText_setPosition( dqOverworldRenderer->cheatText, tilePosition );
-            dqWindow_DrawText( dqOverworldRenderer->cheatText );
-         }
-
-         if ( dqGameConfig->enemyTierCheat )
-         {
-            sprintf_s( dqOverworldRenderer->cheatChars, 32, "%d-%d", tile->minEnemyTier, tile->maxEnemyTier );
+            sprintf_s( dqOverworldRenderer->cheatChars, 64, "R:%d\nE:%d-%d", tile->encounterRate, tile->minEnemyTier, tile->maxEnemyTier );
             sfText_setString( dqOverworldRenderer->cheatText, dqOverworldRenderer->cheatChars );
             sfText_setPosition( dqOverworldRenderer->cheatText, tilePosition );
             dqWindow_DrawText( dqOverworldRenderer->cheatText );

--- a/CDargonQuest/overworld_renderer.h
+++ b/CDargonQuest/overworld_renderer.h
@@ -18,7 +18,7 @@ typedef struct dqOverworldRenderer_t
    sfRectangleShape* mapSwapRect;
    sfFont* cheatFont;
    sfText* cheatText;
-   char cheatChars[32];
+   char cheatChars[64];
 }
 dqOverworldRenderer_t;
 

--- a/CDargonQuest/render_config.c
+++ b/CDargonQuest/render_config.c
@@ -56,7 +56,9 @@ void dqRenderConfig_Init()
    dqRenderConfig->overworldStayFadedSeconds = 0.2f;
    dqRenderConfig->overworldFadeInSeconds = 0.3f;
    dqRenderConfig->cheatFontFilePath = "Resources/Fonts/Consolas.ttf";
-   dqRenderConfig->cheatFontSize = 11;
+   dqRenderConfig->cheatFontSize = 30;
+   dqRenderConfig->cheatFontScale.x = 0.2f;
+   dqRenderConfig->cheatFontScale.y = 0.2f;
    dqRenderConfig->cheatLetterSpacing = 0.1f;
    dqRenderConfig->cheatFontColor = sfWhite;
 }

--- a/CDargonQuest/render_config.h
+++ b/CDargonQuest/render_config.h
@@ -52,8 +52,10 @@ typedef struct dqRenderConfig_t
    float overworldFadeOutSeconds;
    float overworldStayFadedSeconds;
    float overworldFadeInSeconds;
+
    const char* cheatFontFilePath;
    unsigned int cheatFontSize;
+   sfVector2f cheatFontScale;
    float cheatLetterSpacing;
    sfColor cheatFontColor;
 }


### PR DESCRIPTION
## Overview

The map tile cheats were getting cumbersome, so I just threw them all into "dqtilestat" (incidentally, I found a bug with the cheat checker while doing this, I think it's fixed now). dqtilestat will do the following:

- if a tile is an exit point, it'll turn blue
- otherwise, it'll be green if it's passable and red if it isn't.
- on top of that, the first line of text shows the encounter rate for that tile, and the second line shows the min and max enemy tiers.