### PR TITLE
Added scrolling text support

### DIFF
--- a/CDargonQuest/battle_renderer.c
+++ b/CDargonQuest/battle_renderer.c
@@ -22,7 +22,7 @@ void dqBattleRenderer_Render()
    dqDialogRenderer_DrawBorder( dqRenderConfig->battleMessageDialogPos,
                                 dqRenderConfig->battleMessageDialogWidth,
                                 dqRenderConfig->battleMessageDialogHeight );
-   dqDialogRenderer_DrawText( textPos,
-                              "Imagine this is some crazy battle against zombies and dragons or whatever, and you've got like one health left but you can't run away. Sweet, right?!",
-                              dqRenderConfig->battleMessageDialogWidth - 2 );
+   dqDialogRenderer_ScrollText( textPos,
+                                "Imagine this is some crazy battle against zombies and dragons or whatever, and you've got like 1 health left but you can't run away. Sweet, right?!",
+                                dqRenderConfig->battleMessageDialogWidth - 2 );
 }

--- a/CDargonQuest/dialog_renderer.h
+++ b/CDargonQuest/dialog_renderer.h
@@ -4,6 +4,11 @@
 
 typedef struct dqDialogRenderer_t
 {
+   sfBool isScrolling;
+   sfBool hasScrolled;
+   float scrollElapsedSeconds;
+   unsigned int scrollCharCount;
+
    sfSprite* sprite;
    sfIntRect textureRect;
 }
@@ -13,5 +18,7 @@ dqDialogRenderer_t* dqDialogRenderer;
 
 void dqDialogRenderer_Init();
 void dqDialogRenderer_Cleanup();
+void dqDialogRenderer_ResetScroll();
 void dqDialogRenderer_DrawBorder( sfVector2f pos, unsigned int width, unsigned int height );
 void dqDialogRenderer_DrawText( sfVector2f pos, const char* text, unsigned int width );
+void dqDialogRenderer_ScrollText( sfVector2f pos, const char* text, unsigned int width );

--- a/CDargonQuest/game.c
+++ b/CDargonQuest/game.c
@@ -14,6 +14,7 @@
 #include "physics.h"
 #include "map.h"
 #include "transition_renderer.h"
+#include "dialog_renderer.h"
 
 static void dqGame_SetState( dqState_t state )
 {
@@ -116,6 +117,10 @@ static void dqGame_HandleFadedOut()
    else if ( dqGame->state == dqStateBattleTransitionIn )
    {
       // TODO: generate a battle
+
+      // TODO: this will probably go into the battle generation code.
+      // or will it? I'm not sure where this belongs.
+      dqDialogRenderer_ResetScroll();
    }
 }
 
@@ -127,6 +132,7 @@ static void dqGame_HandleFadedIn()
    }
    else if ( dqGame->state == dqStateBattleTransitionIn )
    {
+      // TODO: start the battle
       dqGame_SetState( dqStateBattle );
    }
 }

--- a/CDargonQuest/input_handler.c
+++ b/CDargonQuest/input_handler.c
@@ -6,6 +6,7 @@
 #include "overworld_input_handler.h"
 #include "battle_input_handler.h"
 #include "game.h"
+#include "dialog_renderer.h"
 
 static void dqInputHandler_HandleCheat()
 {
@@ -140,16 +141,19 @@ void dqInputHandler_HandleInput()
 
    dqInputHandler_CheckCheats();
 
-   switch ( dqGame->state )
+   if ( !dqDialogRenderer->isScrolling )
    {
-      case dqStateTitle:
-         dqTitleInputHandler_HandleInput();
-         break;
-      case dqStateOverworld:
-         dqOverworldInputHandler_HandleInput();
-         break;
-      case dqStateBattle:
-         dqBattleInputHandler_HandleInput();
-         break;
+      switch ( dqGame->state )
+      {
+         case dqStateTitle:
+            dqTitleInputHandler_HandleInput();
+            break;
+         case dqStateOverworld:
+            dqOverworldInputHandler_HandleInput();
+            break;
+         case dqStateBattle:
+            dqBattleInputHandler_HandleInput();
+            break;
+      }
    }
 }

--- a/CDargonQuest/render_config.c
+++ b/CDargonQuest/render_config.c
@@ -58,6 +58,8 @@ void dqRenderConfig_Init()
    dqRenderConfig->dialogTileTextureColumns = 10;
    dqRenderConfig->dialogTileTextureRows = 10;
 
+   dqRenderConfig->dialogScrollCharSeconds = 0.01f;
+
    dqRenderConfig->playerTexturePath = "Resources/Sprites/player.png";
 
    dqRenderConfig->overworldFadeOutSeconds = 0.3f;

--- a/CDargonQuest/render_config.h
+++ b/CDargonQuest/render_config.h
@@ -54,6 +54,8 @@ typedef struct dqRenderConfig_t
    unsigned int dialogTileTextureColumns;
    unsigned int dialogTileTextureRows;
 
+   float dialogScrollCharSeconds;
+
    const char* playerTexturePath;
 
    float overworldFadeOutSeconds;


### PR DESCRIPTION
## Overview

This adds the ability to scroll text in a dialog. You can also just instantly display text as well, if you want. It's a little odd how this works, and I suspect the structure of the dialog code might change over time, mostly because it seems weird to me to completely halt input specifically while the dialog is scrolling. It might be better to have some kind of global flag that halts things when the renderer is busy.