### PR TITLE
Fixed diagnostics text resolution

### DIFF
--- a/CDargonQuest/diagnostics_renderer.c
+++ b/CDargonQuest/diagnostics_renderer.c
@@ -24,10 +24,11 @@ void dqDiagnosticsRenderer_Init()
    dqDiagnosticsRenderer->text = sfText_create();
    sfText_setFont( dqDiagnosticsRenderer->text, dqDiagnosticsRenderer->font );
    sfText_setCharacterSize( dqDiagnosticsRenderer->text, dqRenderConfig->diagnosticsFontSize );
+   sfText_setScale( dqDiagnosticsRenderer->text, dqRenderConfig->diagnosticsFontScale );
    sfText_setFillColor( dqDiagnosticsRenderer->text, dqRenderConfig->diagnosticsFontColor );
 
    dqDiagnosticsRenderer->lineSpacing = sfFont_getLineSpacing( dqDiagnosticsRenderer->font,
-                                                               sfText_getCharacterSize( dqDiagnosticsRenderer->text ) );
+                                                               sfText_getCharacterSize( dqDiagnosticsRenderer->text ) ) * dqRenderConfig->diagnosticsFontScale.x;
 
    dqDiagnosticsRenderer->currentFrameRateCache = 0;
    dqDiagnosticsRenderer->averageFrameRateCache = 0;

--- a/CDargonQuest/render_config.c
+++ b/CDargonQuest/render_config.c
@@ -19,12 +19,14 @@ void dqRenderConfig_Init()
 
    dqRenderConfig->showDiagnostics = sfFalse;
    dqRenderConfig->diagnosticsFontFilePath = "Resources/Fonts/Consolas.ttf";
-   dqRenderConfig->diagnosticsFontSize = 10;
+   dqRenderConfig->diagnosticsFontSize = 30;
+   dqRenderConfig->diagnosticsFontScale.x = 0.2f;
+   dqRenderConfig->diagnosticsFontScale.y = 0.2f;
    dqRenderConfig->diagnosticsFontColor = sfWhite;
    dqRenderConfig->diagnosticsBackgroundColor = sfBlue;
-   dqRenderConfig->diagnosticsWidth = 180;
-   dqRenderConfig->diagnosticsHeight = 96;
-   dqRenderConfig->diagnosticsPadding = 10;
+   dqRenderConfig->diagnosticsWidth = 108;
+   dqRenderConfig->diagnosticsHeight = 60;
+   dqRenderConfig->diagnosticsPadding = 8;
    dqRenderConfig->diagnosticsLineWidth = 40;
    dqRenderConfig->diagnosticsRefreshRate = 0.25f;
 

--- a/CDargonQuest/render_config.h
+++ b/CDargonQuest/render_config.h
@@ -18,6 +18,7 @@ typedef struct dqRenderConfig_t
    sfBool showDiagnostics;
    const char* diagnosticsFontFilePath;
    unsigned int diagnosticsFontSize;
+   sfVector2f diagnosticsFontScale;
    sfColor diagnosticsFontColor;
    sfColor diagnosticsBackgroundColor;
    float diagnosticsWidth;


### PR DESCRIPTION
## Overview

I found out earlier that even if you expand the view to the point where text is anti-aliased to hell, you can use SFML's scaling to make it sharp again. This PR does that for diagnostics text.